### PR TITLE
feat(icons): add new @opulen/icons package with build setup

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,0 +1,30 @@
+
+# Opulen Icons
+
+React Icons library for Opulen UI library
+
+
+## Installation
+
+Install Splendid React Icons
+
+```bash
+  npm install @opulen/icons
+  bun add @opulen/icons
+```
+    
+## Usage/Examples
+
+```javascript
+import { IconUserFilled } from "@opulen/icons"
+
+function App() {
+  return <IconUserFilled />
+}
+```
+
+
+## Authors
+
+- [Opulen Authors](https://www.github.com/orgs/opulen/people)
+

--- a/packages/icons/build.ts
+++ b/packages/icons/build.ts
@@ -1,0 +1,8 @@
+await Bun.build({
+  entrypoints: ["./src/index.ts"],
+  outdir: "./dist",
+  format: "esm",
+  minify: process.argv.includes("--minify"),
+  sourcemap: "linked",
+  external: ["*"],
+});

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@opulen/icons",
+  "description": "React icons for Opulen UI components.",
+  "version": "0.0.0.canary.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opulen/opulen.git"
+  },
+  "author": {
+    "name": "Opulen",
+    "email": "B3L8o@example.com",
+    "url": "https://opulen.com"
+  },
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "dist": "bun build.ts && tsc --project tsconfig.json",
+    "publish:canary": "bun publish --access public --tag canary"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@tabler/icons-react": "^3.31.0"
+  }
+}

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,0 +1,1 @@
+export * from "@tabler/icons-react"

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["./src/*.ts", "./src/*.tsx"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}


### PR DESCRIPTION
Introduce a new React icons package for Opulen UI components.  
Add source exports from @tabler/icons-react and configure Bun build  
to output ESM modules with optional minification and sourcemaps.  

Include TypeScript configuration for source and output files, and  
define package metadata, scripts, and dependencies. Provide usage  
instructions and author info in the README to support adoption.