### PR TITLE
fix(package.json): correct version format in icons package

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opulen/icons",
   "description": "React icons for Opulen UI components.",
-  "version": "0.0.0.canary.0",
+  "version": "0.0.0-canary.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/opulen/opulen.git"


### PR DESCRIPTION
Change the version string in @opulen/icons from "0.0.0.canary.0" to
"0.0.0-canary.0" to follow proper semantic versioning format. This
ensures compatibility with package managers and version parsers.